### PR TITLE
fix(sessions): disallow duplicate user streams

### DIFF
--- a/masterbase/app.py
+++ b/masterbase/app.py
@@ -37,6 +37,7 @@ from masterbase.lib import (
     provision_api_key,
     session_closed,
     session_id_from_handle,
+    set_open_true,
     start_session_helper,
     steam_id_from_api_key,
     update_api_key,
@@ -249,6 +250,8 @@ class DemoHandler(WebsocketListener):
         if session_open:
             logger.info("User is already streaming data, closing!")
             await socket.close()
+
+        await set_open_true(socket.app.state.engine, steam_id, session_id)
 
         path = make_demo_path(session_id)
 

--- a/masterbase/app.py
+++ b/masterbase/app.py
@@ -14,6 +14,7 @@ from litestar.exceptions import NotAuthorizedException, PermissionDeniedExceptio
 from litestar.handlers import WebsocketListener
 from litestar.handlers.base import BaseRouteHandler
 from litestar.response import Redirect, Stream
+from litestar.stores.memory import MemoryStore
 from sqlalchemy import Engine, create_engine
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
@@ -45,7 +46,7 @@ logger = logging.getLogger(__name__)
 
 
 # use this to ensure client only has one open connection
-streaming_sessions: dict[WebSocket, IO] = {}
+streaming_sessions: dict[WebSocket, IO] = MemoryStore()
 
 
 def get_db_connection(app: Litestar) -> Engine:

--- a/masterbase/app.py
+++ b/masterbase/app.py
@@ -272,6 +272,7 @@ class DemoHandler(WebsocketListener):
         session_id = session_id_from_handle(streaming_sessions[socket])
         logger.info(f"Received socket disconnect from session ID: {session_id}")
         streaming_sessions[socket].close()
+        streaming_sessions.pop(socket)
         await set_open_false(socket.app.state.async_engine, session_id)
 
     def on_receive(self, data: bytes, socket: WebSocket) -> None:

--- a/masterbase/app.py
+++ b/masterbase/app.py
@@ -38,6 +38,7 @@ from masterbase.lib import (
     provision_api_key,
     session_closed,
     session_id_from_handle,
+    set_open_false,
     set_open_true,
     start_session_helper,
     steam_id_from_api_key,
@@ -266,11 +267,12 @@ class DemoHandler(WebsocketListener):
 
         streaming_sessions[socket] = open(path, mode)
 
-    def on_disconnect(self, socket: WebSocket) -> None:  # type: ignore
+    async def on_disconnect(self, socket: WebSocket) -> None:  # type: ignore
         """Close handle on disconnect."""
         session_id = session_id_from_handle(streaming_sessions[socket])
         logger.info(f"Received socket disconnect from session ID: {session_id}")
         streaming_sessions[socket].close()
+        await set_open_false(socket.app.state.async_engine, session_id)
 
     def on_receive(self, data: bytes, socket: WebSocket) -> None:
         """Write data on disconnect."""

--- a/masterbase/lib.py
+++ b/masterbase/lib.py
@@ -111,7 +111,7 @@ async def check_is_active(engine: AsyncEngine, steam_id: str) -> bool:
 
 
 async def check_is_open(engine: AsyncEngine, steam_id: str, session_id: str) -> bool:
-    """Determine if a user is in an active session."""
+    """Determine if a user is streaming data."""
     sql = "SELECT open FROM demo_sessions WHERE steam_id = :steam_id and session_id = :session_id;"
     params = {"steam_id": steam_id, "session_id": session_id}
 
@@ -125,6 +125,19 @@ async def check_is_open(engine: AsyncEngine, steam_id: str, session_id: str) -> 
         is_open = bool(data)
 
         return is_open
+
+
+async def set_open_true(engine: AsyncEngine, steam_id: str, session_id: str) -> None:
+    """Set `open` to true, indicating the user is streaming data."""
+    sql = "UPDATE demo_sessions SET open = true WHERE steam_id = :steam_id and session_id = :session_id;"
+    params = {"steam_id": steam_id, "session_id": session_id}
+
+    async with engine.connect() as conn:
+        await conn.execute(
+            sa.text(sql),
+            params,
+        )
+        await conn.commit()
 
 
 async def check_analyst(engine: AsyncEngine, steam_id: str) -> bool:

--- a/masterbase/lib.py
+++ b/masterbase/lib.py
@@ -53,6 +53,19 @@ def steam_id_from_api_key(engine: Engine, api_key: str) -> str:
     return steam_id
 
 
+async def async_steam_id_from_api_key(engine: AsyncEngine, api_key: str) -> str:
+    """Resolve a steam ID from an  API key."""
+    async with engine.connect() as conn:
+        result = await conn.execute(
+            # should use a CTE here...
+            sa.text("SELECT steam_id from api_keys where api_key = :api_key;"),
+            {"api_key": api_key},
+        )
+        steam_id = result.scalar_one()
+
+    return steam_id
+
+
 def _get_latest_session_id(engine: Engine, steam_id: str) -> str | None:
     """Get the latest session_id for a user."""
     with engine.connect() as conn:
@@ -121,7 +134,7 @@ async def check_is_open(engine: AsyncEngine, steam_id: str, session_id: str) -> 
             params,
         )
 
-        data = result.one()
+        data = result.one_or_none()
         is_open = bool(data)
 
         return is_open

--- a/masterbase/lib.py
+++ b/masterbase/lib.py
@@ -134,7 +134,7 @@ async def check_is_open(engine: AsyncEngine, steam_id: str, session_id: str) -> 
             params,
         )
 
-        data = result.one_or_none()
+        data = result.scalar_one_or_none()
         is_open = bool(data)
 
         return is_open
@@ -144,6 +144,19 @@ async def set_open_true(engine: AsyncEngine, steam_id: str, session_id: str) -> 
     """Set `open` to true, indicating the user is streaming data."""
     sql = "UPDATE demo_sessions SET open = true WHERE steam_id = :steam_id and session_id = :session_id;"
     params = {"steam_id": steam_id, "session_id": session_id}
+
+    async with engine.connect() as conn:
+        await conn.execute(
+            sa.text(sql),
+            params,
+        )
+        await conn.commit()
+
+
+async def set_open_false(engine: AsyncEngine, session_id: str) -> None:
+    """Set `open` to false, indicating the user not streaming data."""
+    sql = "UPDATE demo_sessions SET open = false WHERE session_id = :session_id;"
+    params = {"session_id": session_id}
 
     async with engine.connect() as conn:
         await conn.execute(

--- a/migrations/versions/58fb39990d30_initialize.py
+++ b/migrations/versions/58fb39990d30_initialize.py
@@ -38,6 +38,7 @@ def upgrade() -> None:
             session_id varchar,
             demo_name varchar,
             active boolean,
+            open boolean,
             start_time timestamptz,
             end_time timestamptz,
             fake_ip varchar,


### PR DESCRIPTION
Before this change it is possible for a user (likely malicious) to open many websocket streams with the same `session_id` as we had no guard against that. The rule is that a user can only open a stream if they have created a session, but there is nothing stopping a user from creating multiple open streams. This change adds a new field to the DB called `open` that is only set to `true` when we are not open, and set to `false` when we close session.