### PR TITLE
correct guard to allow non-sdr comm servers

### DIFF
--- a/masterbase/guards.py
+++ b/masterbase/guards.py
@@ -3,9 +3,10 @@
 from litestar.connection import ASGIConnection
 from litestar.exceptions import NotAuthorizedException, PermissionDeniedException
 from litestar.handlers.base import BaseRouteHandler
+from sourceserver.sourceserver import SourceError
 
 from masterbase.lib import check_analyst, check_is_active, check_key_exists, session_closed, steam_id_from_api_key
-from masterbase.steam import Server, get_ip_as_integer, get_steam_api_key
+from masterbase.steam import Server, get_ip_as_integer, get_steam_api_key, a2s_server_query
 
 
 def _development_feature_flag(connection: ASGIConnection) -> bool:
@@ -84,4 +85,7 @@ async def valid_session_guard(connection: ASGIConnection, _: BaseRouteHandler) -
     try:
         Server.query_from_params(api_key, converted_fake_ip, fake_port)
     except KeyError:
-        raise NotAuthorizedException("Cannot accept data from a non-existent gameserver!")
+        try:
+            a2s_server_query(converted_fake_ip, fake_port)
+        except SourceError:
+            raise NotAuthorizedException("Cannot accept data from a non-existent gameserver!")

--- a/masterbase/guards.py
+++ b/masterbase/guards.py
@@ -7,7 +7,7 @@ from litestar.handlers.base import BaseRouteHandler
 from sourceserver.sourceserver import SourceError
 
 from masterbase.lib import check_analyst, check_is_active, check_key_exists, session_closed, steam_id_from_api_key
-from masterbase.steam import Server, get_ip_as_integer, get_steam_api_key, a2s_server_query
+from masterbase.steam import Server, get_steam_api_key, a2s_server_query
 
 
 def _development_feature_flag(connection: ASGIConnection) -> bool:

--- a/masterbase/guards.py
+++ b/masterbase/guards.py
@@ -81,7 +81,7 @@ async def valid_session_guard(connection: ASGIConnection, _: BaseRouteHandler) -
 
     fake_ip = connection.query_params["fake_ip"]
     ip, fake_port = fake_ip.split(":")
-    converted_fake_ip: IPv4Address = ip_address(get_ip_as_integer(ip))
+    converted_fake_ip: IPv4Address = ip_address(ip)
     api_key = get_steam_api_key()
 
     try:

--- a/masterbase/steam.py
+++ b/masterbase/steam.py
@@ -220,13 +220,6 @@ class Filters:
         """Add nand filter."""
         raise NotImplementedError
 
-
-def get_ip_as_integer(ip: str) -> int:
-    """Get the fake IP for a server. Wack math from ChatGPT and @Saghetti."""
-    ip_parts = [int(part) for part in ip.split(".")]
-    return (ip_parts[0] * 256 ** 3) + (ip_parts[1] * 256 ** 2) + (ip_parts[2] * 256) + ip_parts[3]
-
-
 QUERY_TYPES: dict[int, str] = {
     1: "ping_data",
     2: "players_data",
@@ -271,11 +264,6 @@ class Server(BaseModel):
     def ip(self) -> IPv4Address:
         """Property to return IP without port."""
         return ip_address(self.addr.split(":")[0])
-
-    @property
-    def ip_as_integer(self) -> int:
-        """Get the fake IP for a server. Wack math from ChatGPT and @Saghetti."""
-        return get_ip_as_integer(str(self.ip))
 
     @staticmethod
     def query_from_params(steam_api_key: str, fake_ip: IPv4Address, fake_port: int) -> dict[str, Any]:

--- a/masterbase/steam.py
+++ b/masterbase/steam.py
@@ -273,7 +273,7 @@ class Server(BaseModel):
         return ip_address(self.addr.split(":")[0])
 
     @property
-    def ip_as_integer(self) -> int:
+    def ip_as_integer(self) -> str:
         """Get the fake IP for a server. Wack math from ChatGPT and @Saghetti."""
         return get_ip_as_integer(str(self.ip))
 

--- a/masterbase/steam.py
+++ b/masterbase/steam.py
@@ -7,6 +7,7 @@ from typing import Any
 import requests
 import toml
 from pydantic import BaseModel
+from sourceserver.sourceserver import SourceServer
 
 STEAM_API_KEY_KEYNAME = "STEAM_API_KEY"
 
@@ -79,27 +80,27 @@ class Filters:
     )
 
     def __init__(
-        self,
-        dedicated: bool | None = None,
-        secure: bool | None = None,
-        gamedir: str | None = None,
-        mapname: str | None = None,  # inconsistency here because polluted namespace with python `map`
-        linux: bool | None = None,
-        password: bool | None = None,
-        empty: bool | None = None,
-        full: bool | None = None,
-        proxy: bool | None = None,
-        appid: int | None = None,
-        napp: int | None = None,
-        noplayers: bool | None = None,
-        white: bool | None = None,
-        gametype: list[str] | str | None = None,
-        gamedata: list[str] | str | None = None,
-        gamedataor: list[str] | str | None = None,
-        name_match: str | None = None,
-        version_match: str | None = None,
-        collapse_addr_hash: bool | None = None,
-        gameaddr: str | None = None,
+            self,
+            dedicated: bool | None = None,
+            secure: bool | None = None,
+            gamedir: str | None = None,
+            mapname: str | None = None,  # inconsistency here because polluted namespace with python `map`
+            linux: bool | None = None,
+            password: bool | None = None,
+            empty: bool | None = None,
+            full: bool | None = None,
+            proxy: bool | None = None,
+            appid: int | None = None,
+            napp: int | None = None,
+            noplayers: bool | None = None,
+            white: bool | None = None,
+            gametype: list[str] | str | None = None,
+            gamedata: list[str] | str | None = None,
+            gamedataor: list[str] | str | None = None,
+            name_match: str | None = None,
+            version_match: str | None = None,
+            collapse_addr_hash: bool | None = None,
+            gameaddr: str | None = None,
     ) -> None:
         """Filter for the api.steampowered.com/IGameServersService/GetServerList/v1 endpoint.
 
@@ -222,7 +223,7 @@ class Filters:
 def get_ip_as_integer(ip: str) -> str:
     """Get the fake IP for a server. Wack math from ChatGPT and @Saghetti."""
     ip_parts = [int(part) for part in ip.split(".")]
-    return (ip_parts[0] * 256**3) + (ip_parts[1] * 256**2) + (ip_parts[2] * 256) + ip_parts[3]
+    return (ip_parts[0] * 256 ** 3) + (ip_parts[1] * 256 ** 2) + (ip_parts[2] * 256) + ip_parts[3]
 
 
 QUERY_TYPES: dict[int, str] = {
@@ -352,6 +353,10 @@ class Query:
         servers = [Server(**server) for server in response["servers"]]
 
         return servers
+
+
+def a2s_server_query(server_ip: str, server_port: int) -> SourceServer:
+    return SourceServer(f"{server_ip}:{server_port}")
 
 
 def is_limited_account(steam_id: str) -> bool:

--- a/masterbase/steam.py
+++ b/masterbase/steam.py
@@ -273,7 +273,7 @@ class Server(BaseModel):
         return ip_address(self.addr.split(":")[0])
 
     @property
-    def ip_as_integer(self) -> str:
+    def ip_as_integer(self) -> int:
         """Get the fake IP for a server. Wack math from ChatGPT and @Saghetti."""
         return get_ip_as_integer(str(self.ip))
 

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform"]
 lock_version = "4.4.1"
-content_hash = "sha256:df98ea4259197262441c40fafc829bf356d14f8b4b5805bf6c158a3ffda0cc00"
+content_hash = "sha256:a9610016cf7af4ba58eec4cae9a443cea964056ca5c07a2dfe8ac5c75d54bf19"
 
 [[package]]
 name = "alembic"
@@ -998,6 +998,15 @@ summary = "Sniff out which async library your code is running under"
 files = [
     {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
     {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
+]
+
+[[package]]
+name = "sourceserver"
+version = "0.10.0"
+summary = "Query Source engine servers over UDP"
+files = [
+    {file = "sourceserver-0.10.0-py3-none-any.whl", hash = "sha256:76a05da43a66fd710041c5b58225a83b17833ef7f35dfd89cff2656962be2ee7"},
+    {file = "sourceserver-0.10.0.tar.gz", hash = "sha256:00f13edbe04ebb28c60592aea6c2c48a0c402c14a983c6076a0a3bf38523df2f"},
 ]
 
 [[package]]

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform"]
 lock_version = "4.4.1"
-content_hash = "sha256:a9610016cf7af4ba58eec4cae9a443cea964056ca5c07a2dfe8ac5c75d54bf19"
+content_hash = "sha256:9e9abf62da68d5b262adfb522560821b8bce4bb5e63a4b8b991f8e2daac7685a"
 
 [[package]]
 name = "alembic"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "greenlet>=3.0.3",
     "uvicorn>=0.27.1",
     "numpy>=1.26.4",
+    "sourceserver>=0.10.0",
 ]
 requires-python = ">=3.10,<3.13"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "uvicorn>=0.27.1",
     "numpy>=1.26.4",
     "sourceserver>=0.10.0",
+    "uvloop>=0.19.0",
 ]
 requires-python = ">=3.10,<3.13"
 readme = "README.md"


### PR DESCRIPTION
We may want to do some additional verifications on the `SourceServer` response we get inside the try-except blocks. But for now this allows demo uploads from comm servers

closes #52 