### PR TITLE
only allow reporting players that exist

### DIFF
--- a/masterbase/app.py
+++ b/masterbase/app.py
@@ -256,12 +256,16 @@ def provision_handler(request: Request) -> str:
         Page of HTML for user.
     """
     data = request.query_params
-    validation_args = {
-        "openid.assoc_handle": data["openid.assoc_handle"],
-        "openid.signed": data["openid.signed"],
-        "openid.sig": data["openid.sig"],
-        "openid.ns": data["openid.ns"],
-    }
+    # KeyError thrown when someone navigates here without a redirect from /provision...
+    try:
+        validation_args = {
+            "openid.assoc_handle": data["openid.assoc_handle"],
+            "openid.signed": data["openid.signed"],
+            "openid.sig": data["openid.sig"],
+            "openid.ns": data["openid.ns"],
+        }
+    except KeyError:
+        return "<span>You aren't supposed to be here!</span>"
 
     signed_args = data["openid.signed"].split(",")
     for item in signed_args:

--- a/masterbase/app.py
+++ b/masterbase/app.py
@@ -50,7 +50,7 @@ from masterbase.lib import (
     update_api_key,
 )
 from masterbase.registers import shutdown_registers, startup_registers
-from masterbase.steam import account_exists, is_limited_account
+from masterbase.steam import is_limited_account
 
 logger = logging.getLogger(__name__)
 

--- a/masterbase/guards.py
+++ b/masterbase/guards.py
@@ -5,7 +5,7 @@ from litestar.exceptions import NotAuthorizedException, PermissionDeniedExceptio
 from litestar.handlers.base import BaseRouteHandler
 
 from masterbase.lib import check_analyst, check_is_active, check_key_exists, session_closed, steam_id_from_api_key
-from masterbase.steam import Server, get_ip_as_integer, get_steam_api_key
+from masterbase.steam import Server, account_exists, get_ip_as_integer, get_steam_api_key
 
 
 def _development_feature_flag(connection: ASGIConnection) -> bool:
@@ -85,3 +85,12 @@ async def valid_session_guard(connection: ASGIConnection, _: BaseRouteHandler) -
         Server.query_from_params(api_key, converted_fake_ip, fake_port)
     except KeyError:
         raise NotAuthorizedException("Cannot accept data from a non-existent gameserver!")
+
+
+async def valid_target_guard(connection: ASGIConnection, _: BaseRouteHandler):
+    """Verify the existence of a target_steam_id, if applicable (otherwise, no-op)."""
+    params = connection.query_params
+    if "target_steam_id" in params:
+        return account_exists(params["target_steam_id"])
+    else:
+        return True

--- a/masterbase/guards.py
+++ b/masterbase/guards.py
@@ -89,5 +89,7 @@ async def valid_session_guard(connection: ASGIConnection, _: BaseRouteHandler) -
 
 async def valid_target_guard(connection: ASGIConnection, _: BaseRouteHandler):
     """Verify the existence of a target_steam_id."""
-    params = connection.query_params
-    return account_exists(params["target_steam_id"])
+    target_steam_id = connection.query_params["target_steam_id"]
+    exists = account_exists(target_steam_id)
+    if not exists:
+        raise PermissionDeniedException(detail="Unknown target_steam_id!")

--- a/masterbase/guards.py
+++ b/masterbase/guards.py
@@ -88,9 +88,6 @@ async def valid_session_guard(connection: ASGIConnection, _: BaseRouteHandler) -
 
 
 async def valid_target_guard(connection: ASGIConnection, _: BaseRouteHandler):
-    """Verify the existence of a target_steam_id, if applicable (otherwise, no-op)."""
+    """Verify the existence of a target_steam_id."""
     params = connection.query_params
-    if "target_steam_id" in params:
-        return account_exists(params["target_steam_id"])
-    else:
-        return True
+    return account_exists(params["target_steam_id"])

--- a/masterbase/steam.py
+++ b/masterbase/steam.py
@@ -372,7 +372,12 @@ def player_summary(steam_id: str) -> dict[str, str | int] | None:
 
 
 def is_limited_account(steam_id: str) -> bool:
-    """Determine if an account is limited or not."""
+    """Determine if an account is limited or not.
+
+    False if the player does not exist.
+    """
+    if not account_exists(steam_id):
+        return False
     player = player_summary(steam_id)
     limited = not bool(player.get("profilestate", False))
     return limited

--- a/masterbase/steam.py
+++ b/masterbase/steam.py
@@ -360,7 +360,7 @@ class Query:
 
 
 @cache
-def player_summary(steam_id: str) -> dict[str, str | int] | None:
+def player_summary(steam_id: str) -> dict[str, str | int]:
     """Retrieve a player summary."""
     url = "https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v2"
     params = {"key": get_steam_api_key(), "steamids": steam_id}
@@ -368,7 +368,7 @@ def player_summary(steam_id: str) -> dict[str, str | int] | None:
     if len(response["response"]["players"]) > 0:
         return response["response"]["players"][0]
     else:
-        return None
+        return {}
 
 
 def is_limited_account(steam_id: str) -> bool:
@@ -385,5 +385,4 @@ def is_limited_account(steam_id: str) -> bool:
 
 def account_exists(steam_id: str) -> bool:
     """Determine if an account exists or not."""
-    player = player_summary(steam_id)
-    return player is not None
+    return bool(player_summary(steam_id))

--- a/masterbase/steam.py
+++ b/masterbase/steam.py
@@ -2,8 +2,10 @@
 
 import json
 import os
+from functools import cache
 from typing import Any
 
+import numpy as np
 import requests
 import toml
 from pydantic import BaseModel
@@ -219,10 +221,13 @@ class Filters:
         raise NotImplementedError
 
 
-def get_ip_as_integer(ip: str) -> str:
-    """Get the fake IP for a server. Wack math from ChatGPT and @Saghetti."""
-    ip_parts = [int(part) for part in ip.split(".")]
-    return (ip_parts[0] * 256**3) + (ip_parts[1] * 256**2) + (ip_parts[2] * 256) + ip_parts[3]
+def get_ip_as_integer(ip: str) -> int:
+    """Get the fake IP for a server as a word.
+
+    Wack math from ChatGPT and @Saghetti.
+    """
+    ip_parts = np.array([int(part) for part in ip.split(".")])
+    return int(np.bitwise_or.reduce(ip_parts << np.arange(24, -1, -8)))
 
 
 QUERY_TYPES: dict[int, str] = {
@@ -354,12 +359,26 @@ class Query:
         return servers
 
 
-def is_limited_account(steam_id: str) -> bool:
-    """Determine if an account is limited or not."""
+@cache
+def player_summary(steam_id: str) -> dict[str, str | int] | None:
+    """Retrieve a player summary."""
     url = "https://api.steampowered.com/ISteamUser/GetPlayerSummaries/v2"
     params = {"key": get_steam_api_key(), "steamids": steam_id}
     response = requests.get(url, params).json()
-    player_data = response["response"]["players"][0]
-    limited = not bool(player_data.get("profilestate", False))
+    if len(response["response"]["players"]) > 0:
+        return response["response"]["players"][0]
+    else:
+        return None
 
+
+def is_limited_account(steam_id: str) -> bool:
+    """Determine if an account is limited or not."""
+    player = player_summary(steam_id)
+    limited = not bool(player.get("profilestate", False))
     return limited
+
+
+def account_exists(steam_id: str) -> bool:
+    """Determine if an account exists or not."""
+    player = player_summary(steam_id)
+    return player is not None

--- a/tests/test_steam.py
+++ b/tests/test_steam.py
@@ -71,7 +71,7 @@ def test_get_steam_api_key(steam_id: str, tmpdir: os.PathLike) -> None:
         get_steam_api_key(key_location)
 
 
-def test_serialize_ip_as_int(int_32: int) -> int:
+def test_serialize_ip_as_int(int_32: int) -> None:
     """Test ``get_ip_as_integer``."""
     ip_str = ".".join(f"{b}" for b in int_32.to_bytes(4, "big"))
     assert int_32 == get_ip_as_integer(ip_str)

--- a/tests/test_steam.py
+++ b/tests/test_steam.py
@@ -2,19 +2,27 @@
 
 import json
 import os
+import random
 from typing import Any
 from uuid import uuid4
 
+import numpy as np
 import pytest
 import toml
 
-from masterbase.steam import STEAM_API_KEY_KEYNAME, Filters, get_steam_api_key
+from masterbase.steam import STEAM_API_KEY_KEYNAME, Filters, get_ip_as_integer, get_steam_api_key
 
 
 @pytest.fixture(scope="session")
 def steam_id() -> str:
     """Random session-scoped Steam ID."""
     return str(uuid4().int)
+
+
+@pytest.fixture(scope="session")
+def int_32() -> int:
+    """Random session-scoped int32."""
+    return random.getrandbits(32)
 
 
 def write_json_steam_id(steam_id: str, tmpdir: os.PathLike) -> str:
@@ -45,7 +53,7 @@ def write_environment_steam_id(steam_id: str) -> str:
 
 
 def test_get_steam_api_key(steam_id: str, tmpdir: os.PathLike) -> None:
-    """Test thhe ``get_steam_api_key`` function."""
+    """Test the ``get_steam_api_key`` function."""
     # test json
     key_location = write_json_steam_id(steam_id, tmpdir)
     assert get_steam_api_key(key_location) == steam_id
@@ -62,6 +70,12 @@ def test_get_steam_api_key(steam_id: str, tmpdir: os.PathLike) -> None:
         key_location = write_environment_steam_id(steam_id)
         os.environ.pop(STEAM_API_KEY_KEYNAME)
         get_steam_api_key(key_location)
+
+
+def test_serialize_ip_as_int(int_32: int) -> int:
+    """Test ``get_ip_as_integer``."""
+    ip_str = ".".join(f"{b}" for b in int_32.to_bytes(4, "big"))
+    assert int_32 == get_ip_as_integer(ip_str)
 
 
 @pytest.mark.parametrize("value,expected", [(True, 1), (False, 0), (None, None)])

--- a/tests/test_steam.py
+++ b/tests/test_steam.py
@@ -6,7 +6,6 @@ import random
 from typing import Any
 from uuid import uuid4
 
-import numpy as np
 import pytest
 import toml
 


### PR DESCRIPTION
We currently accept arbitrary strings as `steam_id`s on the report endpoint. It's possible to use [ISteamUser/GetPlayerSummaries](https://developer.valvesoftware.com/wiki/Steam_Web_API#GetPlayerSummaries_.28v0002.29) to avoid storing any reports for nonexistent players. Caveats:
- Requires the use of a [Steam64 ID](https://developer.valvesoftware.com/wiki/SteamID), not just any string. Is the client doing this? I presume it does because otherwise, no players referenced in prior API calls would have passed `loser` guards, e.g., https://github.com/MegaAntiCheat/masterbase/blob/cb11dc3c20cc501c7c660d5dc8f90be3d7d3a067/masterbase/app.py#L302 — If not, it is still easy to implement; see [steamid-ng](https://crates.io/crates/steamid-ng).
- We still need to determine whether/how we will get enough API hits to do this in real-time.