### PR TITLE
chore(posts): data/body -> pydantic models + list_demos for non-analysts

### DIFF
--- a/masterbase/app.py
+++ b/masterbase/app.py
@@ -171,8 +171,14 @@ async def report_player(request: Request, api_key: str, data: ReportBody) -> dic
     try:
         add_report(engine, data.session_id, str(data.target_steam_id))
         return {"report_added": True}
-    except IntegrityError:
-        raise HTTPException(detail="Unknown `session_id`!", status_code=409)
+    except IntegrityError as e:
+        # case target_steam_id is already reported in that session
+        traceback = str(e.orig.with_traceback(e.__traceback__))  # type: ignore
+        if "already exists" in traceback:
+            detail = f"Target ({data.target_steam_id}) is already reported in that session!"
+        else:
+            detail = f"Session ID ({data.session_id}) is unknown!"
+        raise HTTPException(detail=detail, status_code=409)
 
 
 class DemoHandler(WebsocketListener):

--- a/masterbase/app.py
+++ b/masterbase/app.py
@@ -116,17 +116,31 @@ def late_bytes(request: Request, api_key: str, data: LateBytesBody) -> dict[str,
     return {"late_bytes": True}
 
 
-@get("/list_demos", guards=[valid_key_guard, analyst_guard], sync_to_thread=False)
-def list_demos(
+@get("/analyst_list_demos", guards=[valid_key_guard, analyst_guard], sync_to_thread=False)
+def analyst_list_demos(
     request: Request, api_key: str, page_size: int | None = None, page_number: int | None = None
 ) -> list[dict[str, str]]:
-    """List demo data."""
+    """List all demo data."""
     if page_size is None or page_size >= 50 or page_size < 1:
         page_size = 50
     if page_number is None or page_number < 1:
         page_number = 1
     engine = request.app.state.engine
-    demos = list_demos_helper(engine, api_key, page_size, page_number)
+    demos = list_demos_helper(engine, api_key, page_size, page_number, analyst=True)
+    return demos
+
+
+@get("/list_demos", guards=[valid_key_guard], sync_to_thread=False)
+def list_demos(
+    request: Request, api_key: str, page_size: int | None = None, page_number: int | None = None
+) -> list[dict[str, str]]:
+    """List demo data for user with `api_key`."""
+    if page_size is None or page_size >= 50 or page_size < 1:
+        page_size = 50
+    if page_number is None or page_number < 1:
+        page_number = 1
+    engine = request.app.state.engine
+    demos = list_demos_helper(engine, api_key, page_size, page_number, analyst=False)
     return demos
 
 
@@ -347,6 +361,7 @@ app = Litestar(
         late_bytes,
         demodata,
         list_demos,
+        analyst_list_demos,
         report_player,
     ],
     on_shutdown=shutdown_registers,

--- a/masterbase/app.py
+++ b/masterbase/app.py
@@ -165,11 +165,11 @@ async def report_player(request: Request, api_key: str, data: ReportBody) -> dic
     """Add a player report."""
     engine = request.app.state.engine
 
-    exists = account_exists(data.target_steam_id)
+    exists = account_exists(str(data.target_steam_id))
     if not exists:
         raise PermissionDeniedException(detail="Unknown target_steam_id!")
     try:
-        add_report(engine, data.session_id, data.target_steam_id)
+        add_report(engine, data.session_id, str(data.target_steam_id))
         return {"report_added": True}
     except IntegrityError:
         raise HTTPException(detail="Unknown `session_id`!", status_code=409)

--- a/masterbase/app.py
+++ b/masterbase/app.py
@@ -42,6 +42,7 @@ from masterbase.lib import (
     late_bytes_helper,
     list_demos_helper,
     provision_api_key,
+    resolve_hostname,
     set_open_false,
     set_open_true,
     start_session_helper,
@@ -80,6 +81,8 @@ def session_id(
     _session_id = generate_uuid4_int()
     engine = request.app.state.engine
     steam_id = steam_id_from_api_key(engine, api_key)
+    to_resolve, port = fake_ip.split(":")
+    fake_ip = f"{resolve_hostname(fake_ip)}:{port}"
     start_session_helper(engine, steam_id, str(_session_id), demo_name, fake_ip, map)
 
     return {"session_id": _session_id}

--- a/masterbase/guards.py
+++ b/masterbase/guards.py
@@ -4,7 +4,14 @@ from litestar.connection import ASGIConnection
 from litestar.exceptions import NotAuthorizedException, PermissionDeniedException
 from litestar.handlers.base import BaseRouteHandler
 
-from masterbase.lib import check_analyst, check_is_active, check_key_exists, session_closed, steam_id_from_api_key
+from masterbase.lib import (
+    check_analyst,
+    check_is_active,
+    check_key_exists,
+    resolve_hostname,
+    session_closed,
+    steam_id_from_api_key,
+)
 from masterbase.steam import Query, Server, get_ip_as_integer, get_steam_api_key
 
 
@@ -79,6 +86,9 @@ async def valid_session_guard(connection: ASGIConnection, _: BaseRouteHandler) -
 
     api_key = get_steam_api_key()
     fake_ip = connection.query_params["fake_ip"]
+
+    to_resolve, port = fake_ip.split(":")
+    fake_ip = f"{resolve_hostname(fake_ip)}:{port}"
 
     # 169 servers are behind SDR...
     if fake_ip.startswith("169"):

--- a/masterbase/lib.py
+++ b/masterbase/lib.py
@@ -4,6 +4,7 @@ import hashlib
 import logging
 import os
 import secrets
+import socket
 from datetime import datetime, timezone
 from typing import IO, Any, AsyncGenerator
 from uuid import uuid4
@@ -22,6 +23,11 @@ os.makedirs(DEMOS_PATH, exist_ok=True)
 
 LATE_BYTES_START = 0x420
 LATE_BYTES_END = 0x430
+
+
+def resolve_hostname(hosthame: str) -> str:
+    """Resolve a hostname to an IP."""
+    return socket.gethostbyname(hosthame)
 
 
 def make_db_uri(is_async: bool = False) -> str:

--- a/masterbase/lib.py
+++ b/masterbase/lib.py
@@ -501,6 +501,8 @@ def list_demos_helper(engine: Engine, api_key: str, page_size: int, page_number:
         demo_sessions
     WHERE
         active = false
+    ORDER BY
+        start_time
     LIMIT :page_size OFFSET :offset
     ;
     """

--- a/masterbase/lib.py
+++ b/masterbase/lib.py
@@ -600,7 +600,7 @@ def add_loser(engine: Engine, steam_id: str) -> None:
         conn.commit()
 
 
-def add_report(engine: Engine, target_steam_id: str, session_id: str | None) -> None:
+def add_report(engine: Engine, session_id: str, target_steam_id: str | None) -> None:
     """Submit a hackusation to the database."""
     # TODO: Eventually we need to enforce more rigorous checks
     with engine.connect() as conn:

--- a/masterbase/models.py
+++ b/masterbase/models.py
@@ -1,0 +1,22 @@
+"""Module of pydantic models."""
+
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class ReportBody(BaseModel):
+    """Report model for report post request body."""
+
+    session_id: str
+    target_steam_id: str
+
+
+class LateBytesBody(BaseModel):
+    """Report model for late_bytes post request body."""
+
+    late_bytes: str
+
+    def model_post_init(self, __context: Any) -> None:
+        """Convert late_bytes to bytes."""
+        self.converted_late_bytes = bytes.fromhex(self.late_bytes)

--- a/masterbase/models.py
+++ b/masterbase/models.py
@@ -9,7 +9,7 @@ class ReportBody(BaseModel):
     """Report model for report post request body."""
 
     session_id: str
-    target_steam_id: str
+    target_steam_id: int
 
 
 class LateBytesBody(BaseModel):

--- a/masterbase/models.py
+++ b/masterbase/models.py
@@ -9,7 +9,7 @@ class ReportBody(BaseModel):
     """Report model for report post request body."""
 
     session_id: str
-    target_steam_id: int
+    target_steam_id: str
 
 
 class LateBytesBody(BaseModel):

--- a/migrations/versions/405672cf4046_reports.py
+++ b/migrations/versions/405672cf4046_reports.py
@@ -24,7 +24,8 @@ def upgrade() -> None:
         CREATE TABLE reports (
             session_id varchar REFERENCES demo_sessions,
             target_steam_id varchar,
-            created_at timestamptz
+            created_at timestamptz,
+            PRIMARY KEY (session_id, target_steam_id)
         );
         """
     )


### PR DESCRIPTION
Litestar rocks because previously these would give a nasty error on both server and client with keyerrors/bad request but with the pydantic models I get a beautiful 

```
{'status_code': 400, 'detail': 'Validation failed for POST /report?api_key=some_key', 'extra': [{'message': 'Field required', 'key': 'target_steam_id'}]}
```

Also slightly rework the list_demos endpoint to allow one for analysts and for anyone who isn't an analyst to retrieve their own demo sessions.

Also fixes valid_session_guard to work for non-SDR servers

Also adds primary key to reports table to prevent duplicate reports on the same session