### PR TITLE
feat(core): add player report reasons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Litestar API
 - PostgreSQL DB managed by alembic
+
+## v1.1.0 - 2024-06-07
+
+### Added
+
+- Reasons for player reports (cheater or bot)

--- a/masterbase/app.py
+++ b/masterbase/app.py
@@ -173,7 +173,7 @@ async def report_player(request: Request, api_key: str, data: ReportBody) -> dic
     if not exists:
         raise PermissionDeniedException(detail="Unknown target_steam_id!")
     try:
-        add_report(engine, data.session_id, str(data.target_steam_id))
+        add_report(engine, data.session_id, str(data.target_steam_id), data.reason.value)
         return {"report_added": True}
     except IntegrityError as e:
         # case target_steam_id is already reported in that session

--- a/masterbase/lib.py
+++ b/masterbase/lib.py
@@ -600,7 +600,7 @@ def add_loser(engine: Engine, steam_id: str) -> None:
         conn.commit()
 
 
-def add_report(engine: Engine, session_id: str, target_steam_id: str | None) -> None:
+def add_report(engine: Engine, session_id: str, target_steam_id: str | None, reason: str) -> None:
     """Submit a hackusation to the database."""
     # TODO: Eventually we need to enforce more rigorous checks
     with engine.connect() as conn:
@@ -608,12 +608,12 @@ def add_report(engine: Engine, session_id: str, target_steam_id: str | None) -> 
         conn.execute(
             sa.text(
                 """INSERT INTO reports (
-                    session_id, target_steam_id, created_at
+                    session_id, target_steam_id, created_at, reason
                 ) VALUES (
-                    :session_id, :target_steam_id, :created_at);
+                    :session_id, :target_steam_id, :created_at, :reason);
                 """
             ),
-            {"target_steam_id": target_steam_id, "session_id": session_id, "created_at": created_at},
+            {"target_steam_id": target_steam_id, "session_id": session_id, "created_at": created_at, "reason": reason},
         )
         conn.commit()
 

--- a/masterbase/lib.py
+++ b/masterbase/lib.py
@@ -600,7 +600,7 @@ def add_loser(engine: Engine, steam_id: str) -> None:
         conn.commit()
 
 
-def add_report(engine: Engine, session_id: str, target_steam_id: str | None, reason: str) -> None:
+def add_report(engine: Engine, session_id: str, target_steam_id: str, reason: str) -> None:
     """Submit a hackusation to the database."""
     # TODO: Eventually we need to enforce more rigorous checks
     with engine.connect() as conn:

--- a/masterbase/models.py
+++ b/masterbase/models.py
@@ -8,8 +8,8 @@ from pydantic import BaseModel
 class ReportReason(str, Enum):
     """Valid reasons for reports."""
 
-    bot = "bot"
-    cheater = "cheater"
+    BOT = "bot"
+    CHEATER = "cheater"
 
 
 class ReportBody(BaseModel):

--- a/masterbase/models.py
+++ b/masterbase/models.py
@@ -1,13 +1,16 @@
 """Module of pydantic models."""
 
-from pydantic import BaseModel
 from enum import Enum
+
+from pydantic import BaseModel
 
 
 class ReportReason(str, Enum):
     """Valid reasons for reports."""
+
     bot = "bot"
     cheater = "cheater"
+
 
 class ReportBody(BaseModel):
     """Report model for report post request body."""

--- a/masterbase/models.py
+++ b/masterbase/models.py
@@ -1,13 +1,20 @@
 """Module of pydantic models."""
 
 from pydantic import BaseModel
+from enum import Enum
 
+
+class ReportReason(str, Enum):
+    """Valid reasons for reports."""
+    bot = "bot"
+    cheater = "cheater"
 
 class ReportBody(BaseModel):
     """Report model for report post request body."""
 
     session_id: str
     target_steam_id: int
+    reason: ReportReason
 
 
 class LateBytesBody(BaseModel):

--- a/migrations/versions/f36ba7b55e49_report_reasons.py
+++ b/migrations/versions/f36ba7b55e49_report_reasons.py
@@ -1,0 +1,40 @@
+"""report reasons
+
+Revision ID: f36ba7b55e49
+Revises: 405672cf4046
+Create Date: 2024-06-07 16:49:45.487922
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "f36ba7b55e49"
+down_revision: Union[str, None] = "405672cf4046"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TYPE report_reason AS ENUM ("bot", "cheater");
+
+        ALTER TABLE reports
+        ADD COLUMN report report_reason;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE reports
+        DROP COLUMN reason;
+
+        DROP TYPE report_reason;
+        """
+    )

--- a/migrations/versions/f36ba7b55e49_report_reasons.py
+++ b/migrations/versions/f36ba7b55e49_report_reasons.py
@@ -21,7 +21,7 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
     op.execute(
         """
-        CREATE TYPE report_reason AS ENUM ("bot", "cheater");
+        CREATE TYPE report_reason AS ENUM ('bot', 'cheater');
 
         ALTER TABLE reports
         ADD COLUMN report report_reason;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "api"
-version = "0.1.0"
+version = "1.1.0"
 description = "Opinionated wrapper for the Steam API. Goal is to scrape public data on TF2 severs."
 authors = [
     {name = "jayceslesar", email = "jaycesles@gmail.com"},

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -63,7 +63,7 @@ def test_report_reasons_match(test_client: TestClient[Litestar]) -> None:
             """
             )
         )
-    db_reasons = tuple(row["enumlabel"] for row in cursor)
+    db_reasons = next(zip(*cursor))
     pd_reasons = tuple(variant.value for variant in ReportBody)
     assert db_reasons == pd_reasons, (
         "Database and Pydantic: ORM mismatch!"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -50,9 +50,9 @@ def test_client(steam_id: str, api_key: str) -> Iterator[TestClient[Litestar]]:
             conn.commit()
 
 
-def test_report_reasons_match() -> None:
+def test_report_reasons_match(test_client: TestClient[Litestar]) -> None:
     """Ensure that Pydantic report reasons match the postgres type registry."""
-    with app.state.engine.connect() as conn:
+    with test_client.app.state.engine.connect() as conn:
         cursor = conn.execute(
             sa.text(
                 """
@@ -63,13 +63,13 @@ def test_report_reasons_match() -> None:
             """
             )
         )
-        db_reasons = tuple(row["enumlabel"] for row in cursor)
-        pd_reasons = tuple(variant.value for variant in ReportBody)
-        assert db_reasons == pd_reasons, (
-            "Database and Pydantic: ORM mismatch!"
-            + f"\n\tDatabase accepts {db_reasons}."
-            + f"\n\tPydantic accepts {pd_reasons}."
-        )
+    db_reasons = tuple(row["enumlabel"] for row in cursor)
+    pd_reasons = tuple(variant.value for variant in ReportBody)
+    assert db_reasons == pd_reasons, (
+        "Database and Pydantic: ORM mismatch!"
+        + f"\n\tDatabase accepts {db_reasons}."
+        + f"\n\tPydantic accepts {pd_reasons}."
+    )
 
 
 def test_close_session_no_session(test_client: TestClient[Litestar], api_key: str) -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -56,7 +56,7 @@ def test_report_reasons_match() -> None:
             SELECT enumlabel
             FROM pg_enum
             JOIN pg_type ON pg_enum.enumtypid = pg_type.oid
-            WHERE pg_type.typname = "report_reason";
+            WHERE pg_type.typname = 'report_reason';
             """
         ))
         db_reasons = tuple(row["enumlabel"] for row in cursor)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -64,7 +64,7 @@ def test_report_reasons_match() -> None:
         assert db_reasons == pd_reasons, (
             "Database and Pydantic: ORM mismatch!" +
             f"\n\tDatabase accepts {db_reasons}." +
-            f"\n\tPydaantic accepts {pd_reasons}."
+            f"\n\tPydantic accepts {pd_reasons}."
         )
     
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,7 +11,7 @@ from litestar.testing import TestClient
 
 from masterbase.app import app
 from masterbase.lib import LATE_BYTES_END, LATE_BYTES_START
-from masterbase.models import ReportBody
+from masterbase.models import ReportReason
 
 pytestmark = pytest.mark.integration
 
@@ -64,7 +64,7 @@ def test_report_reasons_match(test_client: TestClient[Litestar]) -> None:
             )
         )
     db_reasons = next(zip(*cursor))
-    pd_reasons = tuple(variant.value for variant in ReportBody)
+    pd_reasons = tuple(variant.value for variant in ReportReason)
     assert db_reasons == pd_reasons, (
         "Database and Pydantic: ORM mismatch!"
         + f"\n\tDatabase accepts {db_reasons}."

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,7 +3,6 @@
 import time
 from typing import Iterator
 
-from masterbase.models import ReportBody
 import pytest
 import sqlalchemy as sa
 from litestar import Litestar
@@ -12,6 +11,7 @@ from litestar.testing import TestClient
 
 from masterbase.app import app
 from masterbase.lib import LATE_BYTES_END, LATE_BYTES_START
+from masterbase.models import ReportBody
 
 pytestmark = pytest.mark.integration
 
@@ -49,24 +49,28 @@ def test_client(steam_id: str, api_key: str) -> Iterator[TestClient[Litestar]]:
             conn.execute(sa.text(sql), {"steam_id": steam_id})
             conn.commit()
 
+
 def test_report_reasons_match() -> None:
+    """Ensure that Pydantic report reasons match the postgres type registry."""
     with app.state.engine.connect() as conn:
-        cursor = conn.execute(sa.text(
-            """
+        cursor = conn.execute(
+            sa.text(
+                """
             SELECT enumlabel
             FROM pg_enum
             JOIN pg_type ON pg_enum.enumtypid = pg_type.oid
             WHERE pg_type.typname = 'report_reason';
             """
-        ))
+            )
+        )
         db_reasons = tuple(row["enumlabel"] for row in cursor)
         pd_reasons = tuple(variant.value for variant in ReportBody)
         assert db_reasons == pd_reasons, (
-            "Database and Pydantic: ORM mismatch!" +
-            f"\n\tDatabase accepts {db_reasons}." +
-            f"\n\tPydantic accepts {pd_reasons}."
+            "Database and Pydantic: ORM mismatch!"
+            + f"\n\tDatabase accepts {db_reasons}."
+            + f"\n\tPydantic accepts {pd_reasons}."
         )
-    
+
 
 def test_close_session_no_session(test_client: TestClient[Litestar], api_key: str) -> None:
     """Test closing a session yields a 403."""


### PR DESCRIPTION
Add functionality for end users to submit WHY they are reporting the accused. 

Changes: 
- add ReportReason enum, include in ReportBody Pydantic model for validation
- add alembic revision to upgrade DB with reasons column in report table and enum type for report reasons
- add test to ensure that database report reasons exist and match the Pydantic model