### PR TITLE
Automate database exports

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,7 +20,14 @@ services:
       context: .
       dockerfile: ./services/db/Dockerfile
     container_name: db
+    depends_on:
+      - s3
     environment:
+      MINIO_HOST: s3
+      MINIO_PORT: 9000
+      MINIO_ACCESS_KEY: MEGASCATTERBOMB
+      MINIO_SECRET_KEY: masterbase
+
       POSTGRES_USER: MEGASCATTERBOMB
       POSTGRES_PASSWORD: masterbase
       POSTGRES_DB: demos

--- a/masterbase/app.py
+++ b/masterbase/app.py
@@ -11,7 +11,6 @@ from litestar import Litestar, MediaType, Request, WebSocket, get, post
 from litestar.exceptions import HTTPException, PermissionDeniedException
 from litestar.handlers import WebsocketListener
 from litestar.response import Redirect
-from minio import S3Error
 from sqlalchemy.exc import IntegrityError
 
 from masterbase.anomaly import DetectionState
@@ -37,7 +36,6 @@ from masterbase.lib import (
     check_steam_id_is_beta_tester,
     close_session_helper,
     demo_blob_name,
-    export_database,
     generate_api_key,
     generate_uuid4_int,
     late_bytes_helper,
@@ -48,7 +46,6 @@ from masterbase.lib import (
     set_open_true,
     start_session_helper,
     stat_db_export,
-    stat_demo_blob,
     steam_id_from_api_key,
     time_until_next_export,
     update_api_key,

--- a/masterbase/app.py
+++ b/masterbase/app.py
@@ -172,7 +172,7 @@ def db_export(request: Request, api_key: str) -> Redirect:
     """Allow the client to download a DB export if it exists; otherwise, 503."""
     minio_client = request.app.state.minio_client
     if stat_db_export(minio_client) is not None:
-        url = minio_client.presigned_get_object("demos", demo_blob_name(session_id))
+        url = minio_client.presigned_get_object("db_exports", "demo_sessions.csv.gz")
         return Redirect(
             path=url,
             status_code=303,

--- a/masterbase/app.py
+++ b/masterbase/app.py
@@ -155,7 +155,7 @@ def list_demos(
     return demos
 
 
-@get("/demodata", guards=[valid_key_guard, session_closed_guard, analyst_guard])
+@get("/demodata", guards=[valid_key_guard, session_closed_guard, analyst_guard], sync_to_thread=False)
 def demodata(request: Request, api_key: str, session_id: str) -> Redirect:
     """Return the demo."""
     minio_client = request.app.state.minio_client
@@ -167,7 +167,7 @@ def demodata(request: Request, api_key: str, session_id: str) -> Redirect:
     )
 
 
-@get("/db_export", guards=[valid_key_guard, analyst_guard])
+@get("/db_export", guards=[valid_key_guard, analyst_guard], sync_to_thread=True)
 def db_export(request: Request, api_key: str) -> Redirect:
     """Allow the client to download a DB export if it exists; otherwise, 503."""
     minio_client = request.app.state.minio_client

--- a/masterbase/app.py
+++ b/masterbase/app.py
@@ -50,7 +50,7 @@ from masterbase.lib import (
     time_until_next_export,
     update_api_key,
 )
-from masterbase.models import LateBytesBody, ReportBody
+from masterbase.models import DBExportBody, LateBytesBody, ReportBody
 from masterbase.registers import shutdown_registers, startup_registers
 from masterbase.steam import account_exists, is_limited_account
 
@@ -168,10 +168,10 @@ def demodata(request: Request, api_key: str, session_id: str) -> Redirect:
 
 
 @get("/db_export", guards=[valid_key_guard, analyst_guard], sync_to_thread=True)
-def db_export(request: Request, api_key: str) -> Redirect:
+def db_export(request: Request, api_key: str, data: DBExportBody) -> Redirect:
     """Allow the client to download a DB export if it exists; otherwise, 503."""
     minio_client = request.app.state.minio_client
-    if stat_db_export(minio_client) is not None:
+    if stat_db_export(minio_client, data.table) is not None:
         url = minio_client.presigned_get_object("db_exports", "demo_sessions.csv.gz")
         return Redirect(
             path=url,

--- a/masterbase/lib.py
+++ b/masterbase/lib.py
@@ -49,7 +49,7 @@ def make_db_uri(is_async: bool = False) -> str:
 
 def export_database():
     """Run the database export script."""
-    return sp.run(["/usr/local/bin/db_export.sh"])
+    return sp.run(["/usr/local/bin/export_db.sh"])
 
 
 def time_until_next_export(grace_period: timedelta = timedelta(minutes=30)):
@@ -497,10 +497,10 @@ def demo_sink_path(session_id: str) -> str:
     return os.path.join(DEMOS_PATH, demo_blob_name(session_id))
 
 
-def stat_db_export(minio_client: Minio) -> BlobStat | None:
-    """Return information on the status of the database export if it exists, else None."""
+def stat_db_export(minio_client: Minio, table) -> BlobStat | None:
+    """Return information on the status of the given table's export if it exists, else None."""
     try:
-        return minio_client.stat_object("db_export", "demo_sessions.csv.gz")
+        return minio_client.stat_object("db_export", f"{table}.csv.gz")
     except S3Error as err:
         if err.code == "NoSuchKey":
             return None

--- a/masterbase/lib.py
+++ b/masterbase/lib.py
@@ -47,9 +47,9 @@ def make_db_uri(is_async: bool = False) -> str:
     return f"{prefix}://{user}:{password}@{host}:{port}/demos"
 
 
-def export_database():
+def export_database(table: str):
     """Run the database export script."""
-    return sp.run(["/usr/local/bin/export_db.sh"])
+    return sp.run(["/usr/local/bin/export_db.sh", table]).check_returncode()
 
 
 def time_until_next_export(grace_period: timedelta = timedelta(minutes=30)):
@@ -497,7 +497,7 @@ def demo_sink_path(session_id: str) -> str:
     return os.path.join(DEMOS_PATH, demo_blob_name(session_id))
 
 
-def stat_db_export(minio_client: Minio, table) -> BlobStat | None:
+def stat_db_export(minio_client: Minio, table: str) -> BlobStat | None:
     """Return information on the status of the given table's export if it exists, else None."""
     try:
         return minio_client.stat_object("db_export", f"{table}.csv.gz")

--- a/masterbase/lib.py
+++ b/masterbase/lib.py
@@ -62,8 +62,8 @@ def time_until_next_export(grace_period: timedelta = timedelta(minutes=30)):
     From: https://stackoverflow.com/a/45986036
     """
     now = datetime.now()
-    tomorrow = now + datetime.timedelta(days=1)
-    return datetime.combine(tomorrow, datetime.min) - now + grace_period
+    tomorrow = now + timedelta(days=1)
+    return datetime.combine(tomorrow, datetime.min.time) - now + grace_period
 
 
 def make_minio_client(is_secure: bool = False) -> Minio:

--- a/masterbase/lib.py
+++ b/masterbase/lib.py
@@ -63,7 +63,7 @@ def time_until_next_export(grace_period: timedelta = timedelta(minutes=30)):
     """
     now = datetime.now()
     tomorrow = now + timedelta(days=1)
-    return datetime.combine(tomorrow, datetime.min.time) - now + grace_period
+    return datetime.combine(tomorrow.date(), datetime.min.time()) - now + grace_period
 
 
 def make_minio_client(is_secure: bool = False) -> Minio:

--- a/masterbase/models.py
+++ b/masterbase/models.py
@@ -2,7 +2,7 @@
 
 from enum import Enum
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 
 class ReportReason(str, Enum):

--- a/masterbase/models.py
+++ b/masterbase/models.py
@@ -2,7 +2,7 @@
 
 from enum import Enum
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class ReportReason(str, Enum):
@@ -18,6 +18,19 @@ class ReportBody(BaseModel):
     session_id: str
     target_steam_id: int
     reason: ReportReason
+
+
+class ExportTable(str, Enum):
+    """Tables to be allowed in database exports."""
+
+    DEMOS = "demo_sessions"
+    REPORTS = "reports"
+
+
+class DBExportBody(BaseModel):
+    """Request body for a database export."""
+
+    table: ExportTable
 
 
 class LateBytesBody(BaseModel):

--- a/services/db/Dockerfile
+++ b/services/db/Dockerfile
@@ -1,5 +1,18 @@
+FROM minio/mc:RELEASE.2024-06-10T16-44-15Z AS mc
 FROM postgres:16.1-bullseye
 
 VOLUME /var/lib/postgresql/data
 
 EXPOSE 5432
+
+RUN mc alias set blobs "http://$MINIO_HOST:$MINIO_PORT" "$MINIO_ACCESS_KEY" "$MINIO_SECRET_KEY"
+
+COPY ./services/db/export_db.sh /usr/local/bin/export_db.sh
+RUN chmod +x /usr/local/bin/export_db.sh
+
+RUN apt-get update && apt-get install -y cron
+RUN mkdir -p /etc/cron.d
+COPY ./services/db/export_db.cron /etc/cron.d/export_db.cron
+RUN chmod 0644 /etc/cron.d/export_db.cron
+RUN crontab /etc/cron.d/export_db.cron
+RUN service cron start

--- a/services/db/export_db.cron
+++ b/services/db/export_db.cron
@@ -1,0 +1,1 @@
+0 0 * * * /usr/local/bin/export_db.sh

--- a/services/db/export_db.sh
+++ b/services/db/export_db.sh
@@ -4,14 +4,15 @@ function execute () {
     psql -U $POSTGRES_USER -d $POSTGRES_NAME -h $POSTGRES_HOST -Atc "$1"
 }
 
+TABLE='demo_sessions'
 COLUMNS=$(execute <<-SQL
     SELECT column_name
     FROM information_schema.columns
-    WHERE table_name = 'demo_sessions'
+    WHERE table_name = '$TABLE'
     AND data_type != 'bytea';
 SQL
 )
-execute <<-SQL | gzip | mc pipe blobs/db_exports/demo_sessions.csv.gz
+execute <<-SQL | gzip | mc pipe blobs/db_exports/$TABLE.csv.gz
     \COPY $TABLE TO STDOUT WITH CSV HEADER
 SQL
 done

--- a/services/db/export_db.sh
+++ b/services/db/export_db.sh
@@ -4,15 +4,20 @@ function execute () {
     psql -U $POSTGRES_USER -d $POSTGRES_NAME -h $POSTGRES_HOST -Atc "$1"
 }
 
-TABLE='demo_sessions'
-COLUMNS=$(execute <<-SQL
-    SELECT column_name
-    FROM information_schema.columns
-    WHERE table_name = '$TABLE'
-    AND data_type != 'bytea';
-SQL
-)
-execute <<-SQL | gzip | mc pipe blobs/db_exports/$TABLE.csv.gz
-    \COPY $TABLE TO STDOUT WITH CSV HEADER
-SQL
+if [ $# -eq 0 ]; then
+    TABLES=('reports' 'demo_sessions')
+else
+    TABLES=("$@")
+fi
+
+for TABLE in "${TABLES[@]}"; do
+    COLUMNS=$(execute "
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_name = '$TABLE'
+        AND data_type != 'bytea';
+    ")
+
+    execute "\COPY $TABLE TO STDOUT WITH CSV HEADER" \
+        | gzip | mc pipe blobs/db_exports/$TABLE.csv.gz
 done

--- a/services/db/export_db.sh
+++ b/services/db/export_db.sh
@@ -1,0 +1,17 @@
+mkdir -p "$EXPORT_DIR"
+
+function execute () {
+    psql -U $POSTGRES_USER -d $POSTGRES_NAME -h $POSTGRES_HOST -Atc "$1"
+}
+
+COLUMNS=$(execute <<-SQL
+    SELECT column_name
+    FROM information_schema.columns
+    WHERE table_name = 'demo_sessions'
+    AND data_type != 'bytea';
+SQL
+)
+execute <<-SQL | gzip | mc pipe blobs/db_exports/demo_sessions.csv.gz
+    \COPY $TABLE TO STDOUT WITH CSV HEADER
+SQL
+done

--- a/services/minio/start.sh
+++ b/services/minio/start.sh
@@ -8,6 +8,7 @@ done
 if [ -f /first_run ]; then
     mc alias set blobs http://localhost:9000 MEGASCATTERBOMB masterbase
     mc mb -p blobs/demos
+    mc mb -p blobs/db_exports
     rm /first_run
 fi
 


### PR DESCRIPTION
* docker-compose.yaml: update the db service to depend on minio
* services/s3/start.sh: create a bucket for DB exports on first run
* services/db/export_db.sh: add a script to export demo_sessions
* services/db/Dockerfile:
  - ensure cron is installed and start crond
  - copy in the export script
* services/db/export_db.cron:
  - add a job to be copied into /etc/cron.d