### PR TITLE
On-demand database exports

### DIFF
--- a/masterbase/app.py
+++ b/masterbase/app.py
@@ -381,7 +381,7 @@ def provision_handler(request: Request) -> str:
         """
 
 
-def reraise_handler(req: Request, err: Exception) -> None:
+def _reraise_handler(req: Request, err: Exception) -> None:
     if req.app.opt["DEVELOPMENT"]:
         raise err
 
@@ -402,7 +402,7 @@ app = Litestar(
         db_export,
     ],
     on_shutdown=shutdown_registers,
-    exception_handlers={HTTPException: reraise_handler},
+    exception_handlers={HTTPException: _reraise_handler},
     opt={"DEVELOPMENT": bool(os.getenv("DEVELOPMENT"))},
 )
 

--- a/masterbase/app.py
+++ b/masterbase/app.py
@@ -166,9 +166,9 @@ async def demodata(request: Request, api_key: str, session_id: str) -> Redirect:
     )
 
 
-@get("/db_export", guards=[valid_key_guard, analyst_guard])
+@get("/db_export", guards=[valid_key_guard, analyst_guard], sync_to_thread=False)
 def db_export(request: Request, api_key: str, data: DBExportBody) -> Stream:
-    """Return a database export of the requested table from within the last `max_age` seconds."""
+    """Return a database export of the requested `table` from within the last `max_age` seconds."""
     engine = request.app.state.engine
     filename = f"demo_sessions-{datetime.now()}.csv"
     return Stream(

--- a/masterbase/app.py
+++ b/masterbase/app.py
@@ -168,7 +168,7 @@ async def demodata(request: Request, api_key: str, session_id: str) -> Redirect:
 
 @get("/db_export", guards=[valid_key_guard, analyst_guard])
 def db_export(request: Request, api_key: str, data: DBExportBody) -> Stream:
-    """Return a database export from within the last `max_age` seconds."""
+    """Return a database export of the requested table from within the last `max_age` seconds."""
     engine = request.app.state.engine
     filename = f"demo_sessions-{datetime.now()}.csv"
     return Stream(

--- a/masterbase/app.py
+++ b/masterbase/app.py
@@ -169,6 +169,8 @@ async def demodata(request: Request, api_key: str, session_id: str) -> Redirect:
 @get("/db_export", guards=[valid_key_guard, analyst_guard])
 def db_export(request: Request, api_key: str, max_age: int) -> Stream:
     """Return a database export from within the last `max_age` seconds."""
+    if max_age < 300:
+        raise HTTPException(status_code=404, detail="`max_age` must be >= 300.")
     engine = request.app.state.engine
     filename = f"demo_sessions-{datetime.now()}.csv"
     return Stream(

--- a/masterbase/app.py
+++ b/masterbase/app.py
@@ -167,7 +167,7 @@ async def demodata(request: Request, api_key: str, session_id: str) -> Redirect:
 
 
 @get("/db_export", guards=[valid_key_guard, analyst_guard], sync_to_thread=False)
-def db_export(request: Request, api_key: str, table: ExportTable, max_age: int | None = 300) -> Stream:
+def db_export(request: Request, api_key: str, table: ExportTable, max_age: int = 300) -> Stream:
     """Return a database export of the requested `table` from within the last `max_age` seconds."""
     if max_age < 300:
         raise PermissionDeniedException(detail="`max_age` must be at least 300", status_code=403)
@@ -381,11 +381,6 @@ def provision_handler(request: Request) -> str:
         """
 
 
-def _reraise_handler(req: Request, err: Exception) -> None:
-    if req.app.opt["DEVELOPMENT"]:
-        raise err
-
-
 app = Litestar(
     on_startup=startup_registers,
     route_handlers=[
@@ -402,7 +397,6 @@ app = Litestar(
         db_export,
     ],
     on_shutdown=shutdown_registers,
-    exception_handlers={HTTPException: _reraise_handler},
     opt={"DEVELOPMENT": bool(os.getenv("DEVELOPMENT"))},
 )
 

--- a/masterbase/lib.py
+++ b/masterbase/lib.py
@@ -58,7 +58,7 @@ def make_minio_client(is_secure: bool = False) -> Minio:
 
 def db_export_chunks(engine: Engine, table: str) -> Generator[bytes, None, None]:
     """Export the given table as an iterable of csv chunks."""
-    queue = Queue()
+    queue: Queue = Queue()
     sentinel = object()
 
     def worker():

--- a/masterbase/lib.py
+++ b/masterbase/lib.py
@@ -97,7 +97,7 @@ def db_export_cached(
         cache_hit = False
 
     if cache_hit:
-        with open(cache_name, "r") as lines:
+        with open(cache_name, "rb") as lines:
             yield from lines
     else:
         with open(cache_name, "wb+") as cache:

--- a/masterbase/lib.py
+++ b/masterbase/lib.py
@@ -67,11 +67,14 @@ def db_export_chunks(engine: Engine) -> Generator[bytes, None, None]:
         def write(self, data):
             channel.send(data)
 
-    with engine.raw_connection() as conn:
+    try:
+        conn = engine.raw_connection()
         cursor = conn.cursor()
         cursor.copy_expert("COPY 'demo_sessions' TO STDOUT WITH CSV HEADER", Sender())
         conn.commit()
         yield from channel
+    finally:
+        conn.close()
 
 
 def db_export_cached(

--- a/masterbase/models.py
+++ b/masterbase/models.py
@@ -27,13 +27,6 @@ class ExportTable(str, Enum):
     REPORTS = "reports"
 
 
-class DBExportBody(BaseModel):
-    """Request body for a database export."""
-
-    table: ExportTable
-    max_age: int = Field(ge=300)
-
-
 class LateBytesBody(BaseModel):
     """Report model for late_bytes post request body."""
 

--- a/masterbase/models.py
+++ b/masterbase/models.py
@@ -2,7 +2,7 @@
 
 from enum import Enum
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 
 class ReportReason(str, Enum):

--- a/masterbase/models.py
+++ b/masterbase/models.py
@@ -2,7 +2,7 @@
 
 from enum import Enum
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class ReportReason(str, Enum):
@@ -18,6 +18,20 @@ class ReportBody(BaseModel):
     session_id: str
     target_steam_id: int
     reason: ReportReason
+
+
+class ExportTable(str, Enum):
+    """Tables to be allowed in database exports."""
+
+    DEMOS = "demo_sessions"
+    REPORTS = "reports"
+
+
+class DBExportBody(BaseModel):
+    """Request body for a database export."""
+
+    table: ExportTable
+    max_age: int = Field(ge=300)
 
 
 class LateBytesBody(BaseModel):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -143,7 +143,9 @@ def test_db_exports(test_client: TestClient[Litestar], api_key: str) -> None:
     test_client.get("/close_session", params={"api_key": api_key})
     response = test_client.get("/db_export", params={"api_key": api_key, "table": "reports"})
     response_records = csv.DictReader(io.TextIOWrapper(io.BytesIO(response.content)))
-    assert set(response_records.fieldnames).issuperset({"session_id", "target_steam_id", "reason"})
+    assert response_records.fieldnames is not None and set(response_records.fieldnames).issuperset(
+        {"session_id", "target_steam_id", "reason"}
+    )
     returned = sorted(
         (
             (int(record["session_id"]), record["target_steam_id"], record["reason"])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -44,9 +44,9 @@ def test_client(steam_id: str, api_key: str) -> Iterator[TestClient[Litestar]]:
         yield client
 
         with app.state.engine.connect() as conn:
-            sql = "DELETE FROM demo_sessions;"
-            conn.execute(sa.text(sql))
             sql = "TRUNCATE TABLE reports CASCADE;"
+            conn.execute(sa.text(sql))
+            sql = "TRUNCATE TABLE demo_sessions CASCADE;"
             conn.execute(sa.text(sql))
             sql = "DELETE FROM api_keys WHERE api_key = :api_key;"
             conn.execute(sa.text(sql), {"api_key": api_key})

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -136,7 +136,7 @@ def test_db_exports(test_client: TestClient[Litestar], api_key: str) -> None:
     for i in range(10):
         reason = "cheater" if i % 2 == 0 else "bot"
         target_steam_id = f"{i:020d}"
-        record = {"session_id": str(session_id), "target_steam_id": target_steam_id, "reason": reason}
+        record = {"session_id": session_id, "target_steam_id": target_steam_id, "reason": reason}
         add_report(test_client.app.state.engine, **record)
         expected.append((session_id, target_steam_id, reason))
 
@@ -146,7 +146,7 @@ def test_db_exports(test_client: TestClient[Litestar], api_key: str) -> None:
     assert set(response_records.fieldnames).issuperset({"session_id", "target_steam_id", "reason"})
     returned = sorted(
         (
-            (record["session_id"], record["target_steam_id"], record["reason"])
+            (int(record["session_id"]), record["target_steam_id"], record["reason"])
             for record in sorted(response_records, key=lambda record: record["created_at"])
         )
     )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,7 @@
 """Integration tests."""
 
+import csv
+import io
 import time
 from typing import Iterator
 
@@ -11,7 +13,7 @@ from litestar.status_codes import HTTP_200_OK, HTTP_201_CREATED, HTTP_403_FORBID
 from litestar.testing import TestClient
 
 from masterbase.app import app
-from masterbase.lib import LATE_BYTES_END, LATE_BYTES_START
+from masterbase.lib import LATE_BYTES_END, LATE_BYTES_START, add_report
 from masterbase.models import ReportReason
 
 pytestmark = pytest.mark.integration
@@ -43,6 +45,8 @@ def test_client(steam_id: str, api_key: str) -> Iterator[TestClient[Litestar]]:
 
         with app.state.engine.connect() as conn:
             sql = "DELETE FROM demo_sessions;"
+            conn.execute(sa.text(sql))
+            sql = "DELETE FROM reports;"
             conn.execute(sa.text(sql))
             sql = "DELETE FROM api_keys WHERE api_key = :api_key;"
             conn.execute(sa.text(sql), {"api_key": api_key})
@@ -118,3 +122,24 @@ def test_demo_streaming(test_client: TestClient[Litestar], api_key: str) -> None
         demo_in = f.read()
         demo_in = demo_in[:LATE_BYTES_START] + bytes.fromhex(late_bytes_hex) + demo_in[LATE_BYTES_END:]
         assert demo_in == demo_out
+
+
+def test_db_exports(test_client: TestClient[Litestar], api_key: str) -> None:
+    """Test on-demand exports from the database."""
+    session_id_response = test_client.get(
+        "/session_id",
+        params={"api_key": api_key, "fake_ip": "169.254.215.11%3A58480", "map": "some_map", "demo_name": "demo.dem"},
+    )
+    session_id = session_id_response.json()["session_id"]
+    # Insert mock reports
+    expected = []
+    for i in range(10):
+        reason = "cheater" if i % 2 == 0 else "bot"
+        record = {"session_id": session_id, "target_steam_id": f"{i:020d}", "reason": reason}
+        add_report(test_client.app.state.engine, **record)
+        expected.append(record)
+
+    test_client.get("/close_session", params={"api_key": api_key})
+    response = test_client.get("/db_export", params={"api_key": api_key, "table": "reports"})
+    returned = csv.DictReader(io.TextIOWrapper(io.BytesIO(response.content)))
+    assert tuple(expected) == tuple(returned)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -145,7 +145,9 @@ def test_db_exports(test_client: TestClient[Litestar], api_key: str) -> None:
     response_records = csv.DictReader(io.TextIOWrapper(io.BytesIO(response.content)))
     assert set(response_records.fieldnames).issuperset({"session_id", "target_steam_id", "reason"})
     returned = sorted(
-        ((record["session_id"], record["target_steam_id"], record["reason"]) for record in response_records),
-        key=lambda record: record["created_at"],
+        (
+            (record["session_id"], record["target_steam_id"], record["reason"])
+            for record in sorted(response_records, key=lambda record: record["created_at"])
+        )
     )
     assert tuple(expected) == returned

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -136,7 +136,7 @@ def test_db_exports(test_client: TestClient[Litestar], api_key: str) -> None:
     for i in range(10):
         reason = "cheater" if i % 2 == 0 else "bot"
         target_steam_id = f"{i:020d}"
-        record = {"session_id": session_id, "target_steam_id": target_steam_id, "reason": reason}
+        record = {"session_id": str(session_id), "target_steam_id": target_steam_id, "reason": reason}
         add_report(test_client.app.state.engine, **record)
         expected.append((session_id, target_steam_id, reason))
 
@@ -150,4 +150,4 @@ def test_db_exports(test_client: TestClient[Litestar], api_key: str) -> None:
             for record in sorted(response_records, key=lambda record: record["created_at"])
         )
     )
-    assert tuple(expected) == returned
+    assert tuple(expected) == tuple(returned)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -46,7 +46,7 @@ def test_client(steam_id: str, api_key: str) -> Iterator[TestClient[Litestar]]:
         with app.state.engine.connect() as conn:
             sql = "DELETE FROM demo_sessions;"
             conn.execute(sa.text(sql))
-            sql = "DELETE FROM reports;"
+            sql = "TRUNCATE TABLE reports CASCADE;"
             conn.execute(sa.text(sql))
             sql = "DELETE FROM api_keys WHERE api_key = :api_key;"
             conn.execute(sa.text(sql), {"api_key": api_key})


### PR DESCRIPTION
The intent is that this endpoint's eligibility as upstream functionality is mutually exclusive with #71. One or the other should be decided upon for implementation. I'm in favor of this model personally ( it is totally not because I got to use previously unexplored coroutine hacks ).