### PR TITLE
upsert new reason on conflict

### DIFF
--- a/masterbase/app.py
+++ b/masterbase/app.py
@@ -176,14 +176,8 @@ async def report_player(request: Request, api_key: str, data: ReportBody) -> dic
     try:
         add_report(engine, data.session_id, str(data.target_steam_id), data.reason.value)
         return {"report_added": True}
-    except IntegrityError as e:
-        # case target_steam_id is already reported in that session
-        traceback = str(e.orig.with_traceback(e.__traceback__))  # type: ignore
-        if "already exists" in traceback:
-            detail = f"Target ({data.target_steam_id}) is already reported in that session!"
-        else:
-            detail = f"Session ID ({data.session_id}) is unknown!"
-        raise HTTPException(detail=detail, status_code=409)
+    except IntegrityError:
+        raise HTTPException(detail=f"Unknown session ID {data.session_id}", status_code=402)
 
 
 class DemoHandler(WebsocketListener):


### PR DESCRIPTION
I'd prefer if we could append multiple reports of the same target so they didn't have to be mutually exclusive / we could audit the edits, but that's out of scope here. Fixes #76.