### PR TITLE
fix(session_id): return int

### DIFF
--- a/masterbase/app.py
+++ b/masterbase/app.py
@@ -68,7 +68,7 @@ def session_id(
     demo_name: str,
     fake_ip: str,
     map: str,
-) -> dict[str, str]:
+) -> dict[str, int]:
     """Return a session ID, as well as persist to database.
 
     This is to help us know what is happening downstream:
@@ -89,7 +89,7 @@ def session_id(
         fake_ip = f"{resolve_hostname(fake_ip)}:{port}"
     start_session_helper(engine, steam_id, str(_session_id), demo_name, fake_ip, map)
 
-    return {"session_id": str(_session_id)}
+    return {"session_id": _session_id}
 
 
 @get("/close_session", guards=[valid_key_guard, user_not_in_session_guard], sync_to_thread=False)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -107,6 +107,8 @@ def _send_demo_file(test_client: TestClient[Litestar], api_key: str, session_id:
 def test_demo_streaming(test_client: TestClient[Litestar], api_key: str) -> None:
     """Test streaming a demo to the DB."""
     session_id = _open_mock_session(test_client, api_key).json()["session_id"]
+    assert isinstance(session_id, int)
+
     _send_demo_file(test_client, api_key, session_id)
 
     late_bytes_hex = "7031cf44a7af0100cea70100f5e00400"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -109,7 +109,7 @@ def test_demo_streaming(test_client: TestClient[Litestar], api_key: str) -> None
     session_id = _open_mock_session(test_client, api_key).json()["session_id"]
     assert isinstance(session_id, int)
 
-    _send_demo_file(test_client, api_key, session_id)
+    _send_demo_file(test_client, api_key, str(session_id))
 
     late_bytes_hex = "7031cf44a7af0100cea70100f5e00400"
     late_bytes_response = test_client.post(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -132,7 +132,7 @@ def test_demo_streaming(test_client: TestClient[Litestar], api_key: str) -> None
 
 def test_db_exports(test_client: TestClient[Litestar], api_key: str) -> None:
     """Test on-demand exports from the database."""
-    session_id = _open_mock_session(test_client, api_key).json()["session_id"]
+    session_id = str(_open_mock_session(test_client, api_key).json()["session_id"])
     # Insert mock reports
     expected = []
     for i in range(10):
@@ -159,7 +159,7 @@ def test_db_exports(test_client: TestClient[Litestar], api_key: str) -> None:
 
 def test_upsert_report_reason(test_client: TestClient[Litestar], api_key: str) -> None:
     """Ensure that upserts of reports during the same session work as intended."""
-    session_id = _open_mock_session(test_client, api_key).json()["session_id"]
+    session_id = str(_open_mock_session(test_client, api_key).json()["session_id"])
     engine = test_client.app.state.engine
     target_sid = f"{0:020d}"
     add_report(engine, session_id, target_sid, reason="bot")


### PR DESCRIPTION
In a previous commit this was changed to return a string, but the client backend is expecting an int.

This reverts the change, as we want to return an int as well as adds a test to confirm that the item in the json response is an integer