### PR TITLE
`/db_export`: add `?since`

### DIFF
--- a/masterbase/app.py
+++ b/masterbase/app.py
@@ -1,5 +1,6 @@
 """Litestar Application for serving and ingesting data."""
 
+import json
 import logging
 import os
 from datetime import datetime, timezone
@@ -382,7 +383,11 @@ def readable_exception_handler(_: Request, exception: Exception) -> Response:
     """Handle exceptions subclassed from HTTPException."""
     status_code = getattr(exception, "status_code", HTTP_500_INTERNAL_SERVER_ERROR)
     if isinstance(exception, ValidationException):
-        return Response(json={"detail": "Validation error!", "errors": exception.extra}, status_code=status_code)
+        return Response(
+            content=json.dumps({"detail": "Validation error in request parameters", "errors": exception.extra}),
+            status_code=status_code,
+            media_type=MediaType.JSON,
+        )
     if isinstance(exception, HTTPException):
         content = exception.detail
     else:

--- a/masterbase/lib.py
+++ b/masterbase/lib.py
@@ -56,7 +56,7 @@ def make_minio_client(is_secure: bool = False) -> Minio:
     return Minio(f"{host}:{port}", access_key=access_key, secret_key=secret_key, secure=is_secure)
 
 
-def db_export_chunks(engine: Engine, table: str) -> Generator[bytes, None, None]:
+def db_export_chunks(engine: Engine, table: str, since: datetime | None = None) -> Generator[bytes, None, None]:
     """Export the given table as an iterable of csv chunks."""
 
     class Shunt:
@@ -72,7 +72,17 @@ def db_export_chunks(engine: Engine, table: str) -> Generator[bytes, None, None]
         try:
             with engine.connect() as txn:
                 cursor = txn.connection.dbapi_connection.cursor()
-                cursor.copy_expert(f"COPY {table} TO STDOUT DELIMITER ',' CSV HEADER", shunt)
+                if since:
+                    # make a best-effort attempt to match the postgres timestamp format
+                    # this only works up to hourly precision
+                    tzoffset = int(since.utcoffset().total_seconds() / 3600)
+                    sign = "+" if tzoffset >= 0 else "-"
+                    stamp = since.strftime("%Y-%m-%d %H:%M:%S")
+                    stamp += f"{sign}{tzoffset}"
+                    query = f"(SELECT * FROM {table} WHERE created_at >= '{stamp}')"
+                else:
+                    query = table
+                cursor.copy_expert(f"COPY {query} TO STDOUT DELIMITER ',' CSV HEADER", shunt)
                 queue.put(b"")
         except Exception as err:
             queue.put(err)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -177,7 +177,7 @@ def test_db_exports(test_client: TestClient[Litestar], api_key: str) -> None:
     since = returned_full[4]["created_at"]
 
     tzone = timezone(timedelta(hours=int(since[-3:])))
-    stamp = datetime.strptime("%Y-%m-%d %H:%M:%S", since[:-3]).astimezone(tzone)
+    stamp = datetime.strptime(since[:-3], "%Y-%m-%d %H:%M:%S.%f").replace(tzinfo=tzone)
     response = test_client.get(
         "/db_export", params={"api_key": api_key, "table": "reports", "since": stamp.isoformat()}
     )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -177,7 +177,7 @@ def test_db_exports(test_client: TestClient[Litestar], api_key: str) -> None:
     since = returned_full[4]["created_at"]
 
     tzone = timezone(timedelta(hours=int(since[-3:])))
-    stamp = datetime(*map(int, re.findall(r"\d+", since[:-3])), tzone)
+    stamp = datetime.strptime("%Y-%m-%d %H:%M:%S", since[:-3]).astimezone(tzone)
     response = test_client.get(
         "/db_export", params={"api_key": api_key, "table": "reports", "since": stamp.isoformat()}
     )


### PR DESCRIPTION
This branch implements a query parameter that allows users to request updates that have occurred *`since`* the last time they updated their local copy of the data and enforce `rsync`-style delta-encoding.