### PR TITLE
fix(api keys): robust to replay of provisioned URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.2.1 - 2024-07-21
+
+### Fixed
+
+- Robust to replay of provision_handler
+
 ## v1.2.0 - 2024-07-21
 
 ### Fixed

--- a/masterbase/app.py
+++ b/masterbase/app.py
@@ -348,16 +348,20 @@ def provision_handler(request: Request) -> str:
             add_loser(app.state.engine, steam_id)
             return "limited"
 
-        api_key = check_steam_id_has_api_key(engine, steam_id)
+        api_key, existing_oid_hash = check_steam_id_has_api_key(engine, steam_id)
         new_api_key = generate_api_key()
         invalidated_text = ""
+        oid_hash = str(hash(str(request.url)))
         if api_key is not None:
-            # invalidate old API key and provision a new one
-            invalidated_text = "Your old key was invalidated!"
-            update_api_key(engine, steam_id, new_api_key)
+            if oid_hash == existing_oid_hash:
+                new_api_key = api_key
+            else:
+                # invalidate old API key and provision a new one
+                invalidated_text = "Your old key was invalidated!"
+                update_api_key(engine, steam_id, new_api_key, oid_hash)
 
         else:
-            provision_api_key(engine, steam_id, new_api_key)
+            provision_api_key(engine, steam_id, new_api_key, oid_hash)
 
         text = f"Successfully authenticated! Your API key is '{new_api_key}' {invalidated_text} Do not lose this as the client needs it!"  # noqa
 

--- a/masterbase/app.py
+++ b/masterbase/app.py
@@ -3,6 +3,7 @@
 import logging
 import os
 from datetime import datetime, timezone
+from hmac import compare_digest
 from urllib.parse import unquote, urlencode
 
 import requests
@@ -352,8 +353,8 @@ def provision_handler(request: Request) -> str:
         new_api_key = generate_api_key()
         invalidated_text = ""
         oid_hash = str(hash(str(request.url)))
-        if api_key is not None:
-            if oid_hash == existing_oid_hash:
+        if api_key is not None and existing_oid_hash is not None:
+            if compare_digest(oid_hash, existing_oid_hash):
                 new_api_key = api_key
             else:
                 # invalidate old API key and provision a new one

--- a/migrations/versions/53d7f00c595e_oid_key_hash.py
+++ b/migrations/versions/53d7f00c595e_oid_key_hash.py
@@ -1,0 +1,34 @@
+"""oid-key-hash
+
+Revision ID: 53d7f00c595e
+Revises: 9f376f19995e
+Create Date: 2024-07-21 20:48:37.755305
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '53d7f00c595e'
+down_revision: Union[str, None] = '9f376f19995e'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE api_keys ADD COLUMN oid_hash varchar;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE api_keys DROP COLUMN oid_hash;
+        """
+    )


### PR DESCRIPTION
We had an issue where if someone made a duplicate request with the steam OID url on the `provision_handler` endpoint, this would cause the DB to get a new API key but that not being displayed to the user.  This fixes it by adding the hash of the OID url as a field in the api_keys table, and upon determining that the hashes of the URL's are the same, a new api key is not provisioned.

Tested by running locally and refreshing the page to confirm the text is as expected and the key is not updated in the DB (nor the hash).

The only way to truly get a new key is to start at the `provision` url and run through the steam sign in again

