### PR TITLE
Pruning

### DIFF
--- a/masterbase/app.py
+++ b/masterbase/app.py
@@ -200,8 +200,12 @@ async def demodata(request: Request, api_key: str, session_id: str) -> Stream:
     """Return the demo."""
     minio_client = request.app.state.minio_client
     blob_name = demo_blob_name(session_id)
-    file = minio_client.get_object("demoblobs", blob_name)
-    stat = minio_client.stat_object("demoblobs", blob_name)
+
+    try:
+        file = minio_client.get_object("demoblobs", blob_name)
+        stat = minio_client.stat_object("demoblobs", blob_name)
+    except Exception as exc:
+        raise HTTPException(detail="Demo not found!", status_code=404) from exc
 
     headers = {
         "Content-Disposition": f'attachment; filename="{blob_name}"',

--- a/masterbase/app.py
+++ b/masterbase/app.py
@@ -46,6 +46,7 @@ from masterbase.lib import (
     close_session_helper,
     db_export_chunks,
     demo_blob_name,
+    json_blob_name,
     generate_api_key,
     generate_uuid4_int,
     get_broadcasts,

--- a/masterbase/app.py
+++ b/masterbase/app.py
@@ -23,6 +23,7 @@ CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.dirname(CURRENT_DIR))
 
 # ruff: noqa: E402
+# ruff: noqa: I001
 from masterbase.anomaly import DetectionState
 from masterbase.guards import (
     analyst_guard,
@@ -46,7 +47,6 @@ from masterbase.lib import (
     close_session_helper,
     db_export_chunks,
     demo_blob_name,
-    json_blob_name,
     generate_api_key,
     generate_uuid4_int,
     get_broadcasts,
@@ -65,6 +65,8 @@ from masterbase.lib import (
 from masterbase.models import ExportTable, LateBytesBody, ReportBody
 from masterbase.registers import shutdown_registers, startup_registers
 from masterbase.steam import account_exists, is_limited_account
+
+# ruff: enable
 
 logger = logging.getLogger(__name__)
 
@@ -127,6 +129,7 @@ def close_session(request: Request, api_key: str) -> dict[str, bool]:
     logger.info(msg)
 
     return {"closed_successfully": True}
+
 
 @post("/close_session", guards=[valid_key_guard, user_in_session_guard], sync_to_thread=False)
 def close_with_late_bytes(request: Request, api_key: str, data: LateBytesBody) -> dict[str, bool]:
@@ -262,11 +265,13 @@ async def report_player(request: Request, api_key: str, data: ReportBody) -> dic
     except IntegrityError:
         raise HTTPException(detail=f"Unknown session ID {data.session_id}", status_code=402)
 
+
 @get("/broadcasts", sync_to_thread=False)
 def broadcasts(request: Request) -> list[dict[str, str]]:
     """Return a list of broadcasts."""
     engine = request.app.state.engine
     return get_broadcasts(engine)
+
 
 class DemoHandler(WebsocketListener):
     """Custom Websocket Class."""
@@ -311,7 +316,7 @@ class DemoHandler(WebsocketListener):
         """Close handle on disconnect."""
         if socket in streaming_sessions:
             session_manager = streaming_sessions[socket]
-        else :
+        else:
             logger.warning("Attempting to disconnect from already disconnected socket!")
             return
         logger.info(f"Received socket disconnect from session ID: {session_manager.session_id}")

--- a/masterbase/lib.py
+++ b/masterbase/lib.py
@@ -882,8 +882,15 @@ def cleanup_hung_sessions(engine: Engine) -> None:
     logger.info(f"Checking for hanging sessions...")
     with engine.connect() as conn:
         result = conn.execute(
-            sa.text(
+            sa.text( # We have to delete reports first because of the REFERENCES constraint
                 """
+                DELETE FROM reports WHERE session_id IN (
+                    SELECT session_id FROM demo_sessions
+                    WHERE active = true
+                    OR open = true
+                    OR demo_size IS NULL
+                );
+                
                 DELETE FROM demo_sessions
                 WHERE active = true
                 OR open = true

--- a/masterbase/lib.py
+++ b/masterbase/lib.py
@@ -319,6 +319,7 @@ def get_uningested_demos(engine: Engine, limit: int) -> list[str]:
             active = false
             AND open = false
             AND ingested = false
+            AND pruned = false
             AND demo_size > 0
         ORDER BY
             created_at ASC

--- a/masterbase/registers.py
+++ b/masterbase/registers.py
@@ -7,7 +7,13 @@ from minio import Minio
 from sqlalchemy import Engine, create_engine
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
-from masterbase.lib import make_db_uri, make_minio_client
+from masterbase.lib import (
+    make_db_uri,
+    make_minio_client,
+    cleanup_hung_sessions,
+    cleanup_orphaned_demos,
+    prune_if_necessary
+)
 
 
 def get_minio_connection(app: Litestar) -> Minio:
@@ -54,6 +60,14 @@ async def close_async_db_connection(app: Litestar) -> None:
     if getattr(app.state, "async_engine", None):
         await cast("AsyncEngine", app.state.async_engine).dispose()
 
+def boot_cleanup(app: Litestar) -> None:
+    """Cleanup the database on boot."""
+    engine = app.state.engine
+    minio_client = app.state.minio_client
 
-startup_registers = (get_db_connection, get_async_db_connection, get_minio_connection)
+    cleanup_hung_sessions(engine)
+    cleanup_orphaned_demos(engine, minio_client)
+    prune_if_necessary(engine)
+
+startup_registers = (get_db_connection, get_async_db_connection, get_minio_connection, boot_cleanup)
 shutdown_registers = (close_db_connection, close_async_db_connection)

--- a/masterbase/registers.py
+++ b/masterbase/registers.py
@@ -8,11 +8,11 @@ from sqlalchemy import Engine, create_engine
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 from masterbase.lib import (
-    make_db_uri,
-    make_minio_client,
     cleanup_hung_sessions,
     cleanup_pruned_demos,
-    prune_if_necessary
+    make_db_uri,
+    make_minio_client,
+    prune_if_necessary,
 )
 
 
@@ -60,6 +60,7 @@ async def close_async_db_connection(app: Litestar) -> None:
     if getattr(app.state, "async_engine", None):
         await cast("AsyncEngine", app.state.async_engine).dispose()
 
+
 def boot_cleanup(app: Litestar) -> None:
     """Cleanup the database on boot."""
     engine = app.state.engine
@@ -68,6 +69,7 @@ def boot_cleanup(app: Litestar) -> None:
     cleanup_hung_sessions(engine)
     prune_if_necessary(engine, minio_client)
     cleanup_pruned_demos(engine, minio_client)
+
 
 startup_registers = (get_db_connection, get_async_db_connection, get_minio_connection, boot_cleanup)
 shutdown_registers = (close_db_connection, close_async_db_connection)

--- a/masterbase/registers.py
+++ b/masterbase/registers.py
@@ -11,7 +11,7 @@ from masterbase.lib import (
     make_db_uri,
     make_minio_client,
     cleanup_hung_sessions,
-    cleanup_orphaned_demos,
+    cleanup_pruned_demos,
     prune_if_necessary
 )
 
@@ -66,8 +66,8 @@ def boot_cleanup(app: Litestar) -> None:
     minio_client = app.state.minio_client
 
     cleanup_hung_sessions(engine)
-    cleanup_orphaned_demos(engine, minio_client)
-    prune_if_necessary(engine)
+    prune_if_necessary(engine, minio_client)
+    cleanup_pruned_demos(engine, minio_client)
 
 startup_registers = (get_db_connection, get_async_db_connection, get_minio_connection, boot_cleanup)
 shutdown_registers = (close_db_connection, close_async_db_connection)

--- a/migrations/versions/eba5782c5979_pruning.py
+++ b/migrations/versions/eba5782c5979_pruning.py
@@ -1,0 +1,59 @@
+"""pruning
+
+Revision ID: eba5782c5979
+Revises: f51cab87d3fd
+Create Date: 2025-03-08 13:46:16.132860
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'eba5782c5979'
+down_revision: Union[str, None] = 'f51cab87d3fd'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add pruned column to demo_sessions and default to false"""
+    op.execute(
+        """
+        ALTER TABLE demo_sessions
+        ADD COLUMN pruned boolean;
+
+        UPDATE demo_sessions
+        SET pruned = false;
+
+        ALTER TABLE demo_sessions
+        ALTER COLUMN pruned SET DEFAULT false;
+
+        ALTER TABLE demo_sessions
+        ALTER COLUMN pruned SET NOT NULL;
+        """
+    )
+
+    op.execute(
+        """
+        CREATE TABLE prune_config (
+            min_free_space_gb integer
+        );
+
+        INSERT INTO prune_config (min_free_space_gb)
+            VALUES (50)
+        """
+    )
+
+def downgrade() -> None:
+    """Remove pruned column from demo_sessions"""
+    op.execute(
+        """
+        ALTER TABLE demo_sessions
+        DROP COLUMN pruned;
+
+        DROP TABLE prune_config;
+        """
+    )

--- a/migrations/versions/eba5782c5979_pruning.py
+++ b/migrations/versions/eba5782c5979_pruning.py
@@ -40,11 +40,11 @@ def upgrade() -> None:
     op.execute(
         """
         CREATE TABLE prune_config (
-            max_storage_gb integer
+            max_storage_gb integer PRIMARY KEY DEFAULT 0
         );
 
         INSERT INTO prune_config (max_storage_gb)
-            VALUES (null);
+            VALUES (DEFAULT);
         """
     )
 

--- a/migrations/versions/eba5782c5979_pruning.py
+++ b/migrations/versions/eba5782c5979_pruning.py
@@ -40,7 +40,7 @@ def upgrade() -> None:
     op.execute(
         """
         CREATE TABLE prune_config (
-            max_storage_gb integer PRIMARY KEY DEFAULT 0
+            max_storage_gb integer PRIMARY KEY DEFAULT 0,
             max_prune_ratio double precision DEFAULT 0.05
         );
 

--- a/migrations/versions/eba5782c5979_pruning.py
+++ b/migrations/versions/eba5782c5979_pruning.py
@@ -41,6 +41,7 @@ def upgrade() -> None:
         """
         CREATE TABLE prune_config (
             max_storage_gb integer PRIMARY KEY DEFAULT 0
+            max_prune_ratio double precision DEFAULT 0.05
         );
 
         INSERT INTO prune_config (max_storage_gb)


### PR DESCRIPTION
Changes:

- Allows a storage cap to be specified by the user, and deletes demos with no detections to stay within that limit on boot.
- Always deletes demos with no detections.
- Avoids deleting more than a certain % of demos in one go to mitigate catastrophic data losses (5% by default).
- Automatically cleans up hanging demos (demo blobs with no matching record in the database).

🔥 This PR has been tested in production 🔥

Example log output during boot:
![image](https://github.com/user-attachments/assets/2dd5c462-ca64-4689-8069-5e596b358ae9)

